### PR TITLE
Add fallback placeholders for images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Base URL for Cloudflare Image Delivery
+# Uncomment and set to your account's delivery URL
+CLOUDFLARE_BASE=https://imagedelivery.net/<account_hash>

--- a/README.md
+++ b/README.md
@@ -61,10 +61,14 @@ npm run dev
 
 ## 🖼 Image Hosting (Cloudflare)
 
-Images are delivered using [Cloudflare Image Delivery](https://developers.cloudflare.com/images/image-delivery/urls/):
+Images are delivered using [Cloudflare Image Delivery](https://developers.cloudflare.com/images/image-delivery/urls/).
+Set `CLOUDFLARE_BASE` in an `.env` file to your account's delivery URL, e.g.:
 
+```
+CLOUDFLARE_BASE=https://imagedelivery.net/<account_hash>
+```
 
-https://imagedelivery.net/<account_hash>/<image_id>/<variant>
+Then image paths are generated with `<image_id>/<variant>`. If `CLOUDFLARE_BASE` is not set, local placeholder images are used instead.
 
 ---
 

--- a/public/banner.svg
+++ b/public/banner.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="300">
+  <rect width="100%" height="100%" fill="#cccccc" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#333333" font-size="40">Banner Placeholder</text>
+</svg>

--- a/public/mission.svg
+++ b/public/mission.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="100%" height="100%" fill="#dddddd" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#333333" font-size="40">Mission Image</text>
+</svg>

--- a/public/placeholder.svg
+++ b/public/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="100%" height="100%" fill="#eee" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#888" font-size="24">Image unavailable</text>
+</svg>

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,0 +1,7 @@
+export function cfImage(id: string, variant = "public", fallback = "") {
+  const base = import.meta.env.CLOUDFLARE_BASE;
+  if (base) {
+    return `${base}/${id}/${variant}`;
+  }
+  return fallback;
+}

--- a/src/pages/gallery-masonry.astro
+++ b/src/pages/gallery-masonry.astro
@@ -1,8 +1,7 @@
 ---
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
-
-const cloudflareBase = "https://imagedelivery.net/PocH-U7ndwJHixntYqkoZw";
+import { cfImage } from '../lib/images';
 
 const images = [
   { id: "2926647b-4a25-4d03-6202-0f8a10ae8100", caption: "Our amazing and dedicated crew." },
@@ -51,7 +50,7 @@ const images = [
         {images.map((img) => (
           <div class="break-inside-avoid overflow-hidden rounded-lg shadow hover:shadow-lg transition-shadow duration-300 bg-white">
             <img
-              src={`${cloudflareBase}/${img.id}/public`}
+              src={cfImage(img.id, 'public', '/placeholder.svg')}
               alt={img.caption}
               class="w-full object-cover rounded-t-md hover:scale-105 transition-transform duration-300"
               loading="lazy"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import { cfImage } from '../lib/images';
 ---
 
 <html lang="en">
@@ -32,7 +33,7 @@ import Footer from '../components/Footer.astro';
             J&B McKinney Rentals is a family-run company rooted in Tuscaloosa, Alabama. Our mission is to provide quality, comfortable homes to tenants while revitalizing the neighborhoods we love. From full renovations to careful property management, we treat every project like it's our own.
           </p>
         </div>
-        <img src="https://imagedelivery.net/PocH-U7ndwJHixntYqkoZw/JBM_WebBanner/public" alt="J&B McKinney Banner" class="rounded shadow-lg" />
+        <img src={cfImage('JBM_WebBanner', 'public', '/banner.svg')} alt="J&B McKinney Banner" class="rounded shadow-lg" />
       </div>
     </section>
 
@@ -61,10 +62,10 @@ import Footer from '../components/Footer.astro';
         <h2 class="text-3xl font-bold mb-6">See the Results</h2>
         <p class="text-gray-600 mb-8">We let the transformations speak for themselves.</p>
         <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-          <img src="https://imagedelivery.net/PocH-U7ndwJHixntYqkoZw/JBM_I_0031/jpeg/public" class="rounded shadow-sm hover:scale-105 transition" alt="Preview 1" />
-          <img src="https://imagedelivery.net/PocH-U7ndwJHixntYqkoZw/JBM_I_0026/jpeg/public" class="rounded shadow-sm hover:scale-105 transition" alt="Preview 2" />
-          <img src="https://imagedelivery.net/PocH-U7ndwJHixntYqkoZw/JBM_I_0029/jpeg/public" class="rounded shadow-sm hover:scale-105 transition" alt="Preview 3" />
-          <img src="https://imagedelivery.net/PocH-U7ndwJHixntYqkoZw/JBM_I_0024/jpeg/public" class="rounded shadow-sm hover:scale-105 transition" alt="Preview 4" />
+          <img src={cfImage('JBM_I_0031', 'jpeg/public')} class="rounded shadow-sm hover:scale-105 transition" alt="Preview 1" />
+          <img src={cfImage('JBM_I_0026', 'jpeg/public')} class="rounded shadow-sm hover:scale-105 transition" alt="Preview 2" />
+          <img src={cfImage('JBM_I_0029', 'jpeg/public')} class="rounded shadow-sm hover:scale-105 transition" alt="Preview 3" />
+          <img src={cfImage('JBM_I_0024', 'jpeg/public')} class="rounded shadow-sm hover:scale-105 transition" alt="Preview 4" />
         </div>
         <a href="/gallery-masonry" class="inline-block text-sm text-black font-semibold hover:underline">Browse the full gallery →</a>
       </div>

--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -1,6 +1,7 @@
 ---
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import { cfImage } from '../lib/images';
 ---
 
 <html lang="en">
@@ -20,9 +21,11 @@ import Footer from '../components/Footer.astro';
 
       <section class="grid md:grid-cols-2 gap-10 items-start">
         <div class="animate-fade-in delay-200">
-          <img src="https://imagedelivery.net/PocH-U7ndwJHixntYqkoZw/aafa0fae-55df-4761-a51a-48f19c3c9e00/public"
-               alt="Deirdre Stokes, Founder"
-               class="rounded-xl shadow-md w-full object-cover" />
+          <img
+            src={cfImage('aafa0fae-55df-4761-a51a-48f19c3c9e00', 'public', '/mission.svg')}
+            alt="Deirdre Stokes, Founder"
+            class="rounded-xl shadow-md w-full object-cover"
+          />
         </div>
         <div class="space-y-6 animate-fade-in delay-300">
           <h2 class="text-2xl font-semibold">Deirdre M. Stokes, Founder & CEO</h2>


### PR DESCRIPTION
## Summary
- provide placeholder fallback images when CLOUDFLARE_BASE isn't set
- update banner and mission images to specify fallbacks
- show fallback for gallery images
- document local placeholder behavior

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841a42f165c8321a7ff83387cc27a70